### PR TITLE
Fix: Update Latest Trade Detail WebSocket Event Interface

### DIFF
--- a/src/bingx-socket/bingx-market-socket-stream.ts
+++ b/src/bingx-socket/bingx-market-socket-stream.ts
@@ -16,9 +16,9 @@ import { HeartbeatInterface } from 'bingx-api/bingx-socket/interfaces/heartbeat.
 import {
   LatestTradeEvent,
   MarkerSubscription,
-  MarkerWebsocketEvents,
+  MarketWebsocketEvents,
   SubscriptionType,
-} from 'bingx-api/bingx-socket/events/marker-websocket-events';
+} from 'bingx-api/bingx-socket/events/market-websocket-events';
 
 export class BingxMarketSocketStream {
   private forceClose$ = new BehaviorSubject<boolean>(false);
@@ -36,7 +36,7 @@ export class BingxMarketSocketStream {
   }
 
   private async connect(url: URL): Promise<void> {
-    const socket$ = webSocket<MarkerWebsocketEvents | MarkerSubscription>({
+    const socket$ = webSocket<MarketWebsocketEvents | MarkerSubscription>({
       deserializer: (e) => new BingxWebsocketDeserializer().deserializer(e),
       serializer: (e) => new BingxWebsocketSerializer().serializer(e),
       url: url.toString(),

--- a/src/bingx-socket/events/index.ts
+++ b/src/bingx-socket/events/index.ts
@@ -4,11 +4,11 @@ export {
   SubscriptionType,
   LatestTradeEvent,
   TradeDataType,
-  MarkerWebsocketEvents,
+  MarketWebsocketEvents,
   Price,
   Volume,
   MarkerWebsocketEventCode,
   IsMarketMaker,
   TransactionTimeInMillis,
   MarkerSubscription,
-} from './marker-websocket-events';
+} from './market-websocket-events';

--- a/src/bingx-socket/events/market-websocket-events.ts
+++ b/src/bingx-socket/events/market-websocket-events.ts
@@ -19,16 +19,21 @@ export type TradeDataType = `${TradingPair}@trade`;
 
 export type SubscriptionType = TradeDataType;
 
-export interface MarkerWebsocketEvents {
+export interface MarketWebsocketEvents {
   code: MarkerWebsocketEventCode;
   dataType: SubscriptionType;
 }
 
-export interface LatestTradeEvent extends MarkerWebsocketEvents {
-  dataType: TradeDataType;
+export interface TradeDetail {
   T: TransactionTimeInMillis;
   s: TradingPair;
   m: IsMarketMaker;
   p: Price;
-  v: Volume;
+  v: Volume; // Assuming 'q' represents volume
+}
+
+export interface LatestTradeEvent extends MarketWebsocketEvents {
+  code: MarkerWebsocketEventCode;
+  dataType: TradeDataType;
+  data: TradeDetail[];
 }


### PR DESCRIPTION
### Problem:
The Latest Trade Detail WebSocket Event Interface is currently not in the expected format. All properties except `dataType` should be enclosed within a sub-field called `data`, which should contain an array of objects. This issue needs to be resolved to ensure the interface conforms to the expected format.

### Expected Behavior:
The `LatestTradeEvent` interface should be updated so that all properties except `dataType` are placed within a sub-field called `data`, and this sub-field should contain an array of objects with the respective fields.

## Issue ticket number and link:
- **Ticket Number:** [ 38 ]
- **Link:** [ https://github.com/singlesly/bingx-api/issues/38 ]

### Solution:
To resolve this issue, the `LatestTradeEvent` interface should be modified to match the expected format.

### Changes:
- Updated the `LatestTradeEvent` interface to encapsulate all properties except dataType within a sub-field called `data`.
- Ensured that the `data` field contains an array of objects with the respective fields (`code, T, s, m, p, v`).
- Change the file name `marker-websocket-events.ts` to `market-websocket-events.ts` throughout the whole project.

### Evidence:
 Please see the attached video as evidence.
- Demo: [Link ](https://www.loom.com/share/fb28d7e247e94cd3b48c66c068a2b278)


