### PR TITLE
feat: add delete listen key support

### DIFF
--- a/src/bingx-client/services/listen-key.service.spec.ts
+++ b/src/bingx-client/services/listen-key.service.spec.ts
@@ -1,0 +1,25 @@
+import { ApiAccount } from 'bingx-api/bingx/account/api-account';
+import { BingxDeleteListenKeyEndpoint } from 'bingx-api/bingx/endpoints/bingx-delete-listen-key-endpoint';
+import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/request-executor.interface';
+import { ListenKeyService } from 'bingx-api/bingx-client/services/listen-key.service';
+
+describe('listen key service', () => {
+  it('must delete listen key', async () => {
+    const account = new ApiAccount('api-key', 'secret-key');
+    const requestExecutor: RequestExecutorInterface = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new ListenKeyService(requestExecutor);
+
+    await service.deleteListenKey(account, 'listen-key');
+
+    expect(requestExecutor.execute).toHaveBeenCalledTimes(1);
+    const endpoint = (requestExecutor.execute as jest.Mock).mock.calls[0][0];
+    expect(endpoint).toBeInstanceOf(BingxDeleteListenKeyEndpoint);
+    expect(endpoint.method()).toBe('delete');
+    expect(endpoint.path()).toBe('/openApi/user/auth/userDataStream');
+    expect(endpoint.parameters().asRecord()).toMatchObject({
+      listenKey: 'listen-key',
+    });
+  });
+});

--- a/src/bingx-client/services/listen-key.service.ts
+++ b/src/bingx-client/services/listen-key.service.ts
@@ -1,4 +1,5 @@
 import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { BingxDeleteListenKeyEndpoint } from 'bingx-api/bingx/endpoints/bingx-delete-listen-key-endpoint';
 import { BingxGenerateListenKeyEndpoint } from 'bingx-api/bingx/endpoints/bingx-generate-listen-key-endpoint';
 import { BingxGenerateListenKeyResponse } from 'bingx-api/bingx/endpoints/bingx-generate-listen-key-response';
 import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/request-executor.interface';
@@ -11,6 +12,15 @@ export class ListenKeyService {
   ): Promise<BingxGenerateListenKeyResponse> {
     return this.requestExecutor.execute(
       new BingxGenerateListenKeyEndpoint(account),
+    );
+  }
+
+  async deleteListenKey(
+    account: AccountInterface,
+    listenKey: string,
+  ): Promise<void> {
+    return this.requestExecutor.execute(
+      new BingxDeleteListenKeyEndpoint(listenKey, account),
     );
   }
 }

--- a/src/bingx/endpoints/bingx-delete-listen-key-endpoint.ts
+++ b/src/bingx/endpoints/bingx-delete-listen-key-endpoint.ts
@@ -1,0 +1,33 @@
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { DefaultSignatureParameters } from 'bingx-api/bingx/account/default-signature-parameters';
+import { SignatureParametersInterface } from 'bingx-api/bingx/account/signature-parameters.interface';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+import { Endpoint } from 'bingx-api/bingx/endpoints/endpoint';
+
+export class BingxDeleteListenKeyEndpoint<R = void>
+  extends Endpoint
+  implements EndpointInterface<R>
+{
+  constructor(
+    private readonly listenKey: string,
+    account: AccountInterface,
+  ) {
+    super(account);
+  }
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'delete';
+  }
+
+  parameters(): SignatureParametersInterface {
+    return new DefaultSignatureParameters({
+      listenKey: this.listenKey,
+    });
+  }
+
+  path(): string {
+    return '/openApi/user/auth/userDataStream';
+  }
+
+  readonly t!: R;
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -1,5 +1,6 @@
 export * from './bingx-cancel-all-orders-endpoint';
 export * from './bingx-close-all-positions-endpoint';
+export * from './bingx-delete-listen-key-endpoint';
 export * from './bingx-generate-listen-key-endpoint';
 export * from './bingx-generate-listen-key-response';
 export * from './bingx-get-perpetual-swap-account-asset-endpoint';


### PR DESCRIPTION
## Summary

- add a `BingxDeleteListenKeyEndpoint` for deleting user data stream listen keys
- expose `deleteListenKey(account, listenKey)` on `ListenKeyService`
- add a focused unit test for the delete listen key service path

## Verification

- `npx jest src/bingx-client/services/listen-key.service.spec.ts --runInBand`
- `npx eslint src/bingx/endpoints/bingx-delete-listen-key-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/listen-key.service.ts src/bingx-client/services/listen-key.service.spec.ts`
- `npm run build`
- `npx jest src/bingx-client/bingx-api.client.spec.ts src/bingx-client/services/listen-key.service.spec.ts src/nest-bingx/nest-bingx.module.spec.ts --runInBand`

## Note

`npm test -- --runInBand` timed out locally after the unit suites started; the playground specs require live API credentials and the socket specs are long-running in this environment. The focused service tests and build pass.

Closes #25
