### PR TITLE
feat: add bulk order endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ stream.latestTradeDetail$.subscribe((v) => {})
 * Trade Interface
     - [ ] Trade order test
     - [x] Trade order
-    - [ ] Bulk order
+    - [x] Bulk order
     - [x] One-Click Close All Positions
     - [ ] Cancel an Order
     - [ ] Cancel a Batch of Orders

--- a/src/bingx-client/services/trade.service.spec.ts
+++ b/src/bingx-client/services/trade.service.spec.ts
@@ -1,0 +1,79 @@
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+import { BingxBulkOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-bulk-order-endpoint';
+import { OrderPositionSideEnum } from 'bingx-api/bingx/enums/order-position-side.enum';
+import { OrderSideEnum } from 'bingx-api/bingx/enums/order-side.enum';
+import { OrderTypeEnum } from 'bingx-api/bingx/enums/order-type.enum';
+import { BingxCreateTradeOrderInterface } from 'bingx-api/bingx/interfaces/trade-order.interface';
+import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/request-executor.interface';
+import { TradeService } from 'bingx-api/bingx-client/services/trade.service';
+
+class TestRequestExecutor implements RequestExecutorInterface {
+  public endpoint?: EndpointInterface;
+
+  execute<T>(endpoint: EndpointInterface<T>): Promise<T> {
+    this.endpoint = endpoint;
+    return Promise.resolve({} as T);
+  }
+}
+
+const account: AccountInterface = {
+  getApiKey: () => 'api-key',
+  sign: () => ({
+    toString: () => 'signature',
+    secretKey: () => 'secret-key',
+  }),
+};
+
+describe('TradeService', () => {
+  describe('bulkOrder', () => {
+    it('dispatches the bulk order endpoint', async () => {
+      const executor = new TestRequestExecutor();
+      const service = new TradeService(executor);
+      const orders: BingxCreateTradeOrderInterface[] = [
+        {
+          symbol: 'ETH-USDT',
+          type: OrderTypeEnum.MARKET,
+          side: OrderSideEnum.BUY,
+          positionSide: OrderPositionSideEnum.LONG,
+          quantity: '1',
+        },
+        {
+          symbol: 'BTC-USDT',
+          type: OrderTypeEnum.MARKET,
+          side: OrderSideEnum.BUY,
+          positionSide: OrderPositionSideEnum.LONG,
+          quantity: '0.001',
+        },
+      ];
+
+      await service.bulkOrder(orders, account, 5000);
+
+      const endpoint = executor.endpoint as BingxBulkOrderEndpoint;
+      const parameters = endpoint.parameters().asRecord();
+
+      expect(endpoint).toBeInstanceOf(BingxBulkOrderEndpoint);
+      expect(endpoint.method()).toBe('post');
+      expect(endpoint.path()).toBe('/openApi/swap/v2/trade/batchOrders');
+      expect(JSON.parse(parameters.batchOrders)).toEqual(orders);
+      expect(parameters.recvWindow).toBe('5000');
+      expect(parameters.timestamp).toBeDefined();
+    });
+
+    it('omits recvWindow when it is not provided', async () => {
+      const endpoint = new BingxBulkOrderEndpoint(
+        [
+          {
+            symbol: 'ETH-USDT',
+            type: OrderTypeEnum.MARKET,
+            side: OrderSideEnum.BUY,
+            quantity: '1',
+          },
+        ],
+        account,
+      );
+
+      expect(endpoint.parameters().asRecord().recvWindow).toBeUndefined();
+    });
+  });
+});

--- a/src/bingx-client/services/trade.service.ts
+++ b/src/bingx-client/services/trade.service.ts
@@ -12,6 +12,7 @@ import { BingxSwitchLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-swi
 import { OrderPositionSideEnum } from 'bingx-api/bingx';
 import { BingxUserHistoryOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-endpoint';
 import { BingxCancelOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-cancel-order-endpoint';
+import { BingxBulkOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-bulk-order-endpoint';
 
 export class TradeService {
   constructor(private readonly requestExecutor: RequestExecutorInterface) {}
@@ -31,6 +32,16 @@ export class TradeService {
   ) {
     return this.requestExecutor.execute(
       new BingxTradeOrderEndpoint(order, account),
+    );
+  }
+
+  public async bulkOrder(
+    orders: BingxCreateTradeOrderInterface[],
+    account: AccountInterface,
+    recvWindow?: number,
+  ) {
+    return this.requestExecutor.execute(
+      new BingxBulkOrderEndpoint(orders, account, recvWindow),
     );
   }
 

--- a/src/bingx/endpoints/bingx-bulk-order-endpoint.ts
+++ b/src/bingx/endpoints/bingx-bulk-order-endpoint.ts
@@ -1,0 +1,54 @@
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { DefaultSignatureParameters } from 'bingx-api/bingx/account/default-signature-parameters';
+import { SignatureParametersInterface } from 'bingx-api/bingx/account/signature-parameters.interface';
+import { BingxResponse } from 'bingx-api/bingx/interfaces/bingx-response';
+import { BingxCreateTradeOrderInterface } from 'bingx-api/bingx/interfaces/trade-order.interface';
+import { OrderPositionSideEnum } from 'bingx-api/bingx/enums/order-position-side.enum';
+import { OrderSideEnum } from 'bingx-api/bingx/enums/order-side.enum';
+import { OrderTypeEnum } from 'bingx-api/bingx/enums/order-type.enum';
+import { Endpoint } from 'bingx-api/bingx/endpoints/endpoint';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+
+export interface BingxBulkOrderResponseInterface {
+  orders: Array<{
+    symbol: string;
+    side: OrderSideEnum;
+    type: OrderTypeEnum;
+    positionSide: OrderPositionSideEnum;
+    orderId: number;
+    clientOrderId: string;
+    workingType: string;
+  }>;
+}
+
+export class BingxBulkOrderEndpoint<R = BingxBulkOrderResponseInterface>
+  extends Endpoint
+  implements EndpointInterface<BingxResponse<R>>
+{
+  constructor(
+    private readonly orders: BingxCreateTradeOrderInterface[],
+    account: AccountInterface,
+    private readonly recvWindow?: number,
+  ) {
+    super(account);
+  }
+
+  readonly t!: BingxResponse<R>;
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'post';
+  }
+
+  parameters(): SignatureParametersInterface {
+    return new DefaultSignatureParameters({
+      batchOrders: JSON.stringify(this.orders),
+      ...(this.recvWindow === undefined
+        ? {}
+        : { recvWindow: this.recvWindow.toString(10) }),
+    });
+  }
+
+  path(): string {
+    return '/openApi/swap/v2/trade/batchOrders';
+  }
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -1,4 +1,5 @@
 export * from './bingx-cancel-all-orders-endpoint';
+export * from './bingx-bulk-order-endpoint';
 export * from './bingx-close-all-positions-endpoint';
 export * from './bingx-generate-listen-key-endpoint';
 export * from './bingx-generate-listen-key-response';

--- a/src/bingx/interfaces/websocket-event.ts
+++ b/src/bingx/interfaces/websocket-event.ts
@@ -1,4 +1,3 @@
-import { OrderTypeEnum } from 'bingx-api/bingx/enums/order-type.enum';
 import { OrderSideEnum } from 'bingx-api/bingx/enums/order-side.enum';
 import { OrderStatusEnum } from 'bingx-api/bingx/enums/order-status.enum';
 import { OrderPositionSideEnum } from 'bingx-api/bingx/enums/order-position-side.enum';


### PR DESCRIPTION
Fixes #82

## What changed

- Added a signed `POST /openApi/swap/v2/trade/batchOrders` endpoint for bulk order submission.
- Exposed the endpoint through `TradeService.bulkOrder`.
- Serialized `batchOrders` as the JSON string expected by BingX before signing/request encoding.
- Added focused tests for service dispatch, request shape, and optional `recvWindow` handling.
- Marked the README feature checkbox as supported.
- Removed one unused import so lint passes.

## Tests

- `npm test -- trade.service.spec.ts`
- `npm run lint`
- `npm run build`
