### PR TITLE
feat: add query order endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ stream.latestTradeDetail$.subscribe((v) => {})
     - [ ] Cancel a Batch of Orders
     - [ ] Cancel All Orders
     - [ ] Query all current pending orders
-    - [ ] Query Order
+    - [x] Query Order
     - [ ] Query Margin Mode
     - [ ] Switch Margin Mode
     - [ ] Query Leverage

--- a/src/bingx-client/services/trade.service.spec.ts
+++ b/src/bingx-client/services/trade.service.spec.ts
@@ -1,0 +1,68 @@
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+import { BingxQueryOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-query-order-endpoint';
+import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/request-executor.interface';
+import { TradeService } from 'bingx-api/bingx-client/services/trade.service';
+
+class TestRequestExecutor implements RequestExecutorInterface {
+  public endpoint?: EndpointInterface;
+
+  execute<T>(endpoint: EndpointInterface<T>): Promise<T> {
+    this.endpoint = endpoint;
+    return Promise.resolve({} as T);
+  }
+}
+
+const account: AccountInterface = {
+  getApiKey: () => 'api-key',
+  sign: () => ({
+    toString: () => 'signature',
+    secretKey: () => 'secret-key',
+  }),
+};
+
+describe('TradeService', () => {
+  describe('queryOrder', () => {
+    it('dispatches the query order endpoint', async () => {
+      const executor = new TestRequestExecutor();
+      const service = new TradeService(executor);
+
+      await service.queryOrder(
+        {
+          symbol: 'OP-USDT',
+          orderId: '1736012449498123456',
+          recvWindow: '5000',
+        },
+        account,
+      );
+
+      const endpoint = executor.endpoint as BingxQueryOrderEndpoint;
+      const parameters = endpoint.parameters().asRecord();
+
+      expect(endpoint).toBeInstanceOf(BingxQueryOrderEndpoint);
+      expect(endpoint.method()).toBe('get');
+      expect(endpoint.path()).toBe('/openApi/swap/v2/trade/order');
+      expect(parameters).toMatchObject({
+        symbol: 'OP-USDT',
+        orderId: '1736012449498123456',
+        recvWindow: '5000',
+      });
+      expect(parameters.timestamp).toBeDefined();
+    });
+
+    it('supports querying by client order id', async () => {
+      const endpoint = new BingxQueryOrderEndpoint(
+        {
+          symbol: 'BTC-USDT',
+          clientOrderId: 'client-order-id',
+        },
+        account,
+      );
+
+      expect(endpoint.parameters().asRecord()).toMatchObject({
+        symbol: 'BTC-USDT',
+        clientOrderId: 'client-order-id',
+      });
+    });
+  });
+});

--- a/src/bingx-client/services/trade.service.ts
+++ b/src/bingx-client/services/trade.service.ts
@@ -12,6 +12,8 @@ import { BingxSwitchLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-swi
 import { OrderPositionSideEnum } from 'bingx-api/bingx';
 import { BingxUserHistoryOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-endpoint';
 import { BingxCancelOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-cancel-order-endpoint';
+import { QueryOrderInterface } from 'bingx-api/bingx/interfaces/query-order.interface';
+import { BingxQueryOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-query-order-endpoint';
 
 export class TradeService {
   constructor(private readonly requestExecutor: RequestExecutorInterface) {}
@@ -41,6 +43,15 @@ export class TradeService {
   ) {
     return this.requestExecutor.execute(
       new BingxCancelOrderEndpoint(account, orderId, symbol),
+    );
+  }
+
+  public async queryOrder(
+    order: QueryOrderInterface,
+    account: AccountInterface,
+  ) {
+    return this.requestExecutor.execute(
+      new BingxQueryOrderEndpoint(order, account),
     );
   }
 

--- a/src/bingx/endpoints/bingx-query-order-endpoint.ts
+++ b/src/bingx/endpoints/bingx-query-order-endpoint.ts
@@ -1,0 +1,55 @@
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { DefaultSignatureParameters } from 'bingx-api/bingx/account/default-signature-parameters';
+import { SignatureParametersInterface } from 'bingx-api/bingx/account/signature-parameters.interface';
+import { BingxResponse } from 'bingx-api/bingx/interfaces/bingx-response';
+import { BingxOrderInterface } from 'bingx-api/bingx/interfaces/bingx-order.interface';
+import { QueryOrderInterface } from 'bingx-api/bingx/interfaces/query-order.interface';
+import { Endpoint } from 'bingx-api/bingx/endpoints/endpoint';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+
+export interface BingxQueryOrderResponseInterface {
+  order: BingxOrderInterface & {
+    clientOrderId?: string;
+    workingType?: string;
+    closePosition?: string;
+    stopGuaranteed?: boolean;
+    triggerOrderId?: number;
+  };
+}
+
+export class BingxQueryOrderEndpoint<R = BingxQueryOrderResponseInterface>
+  extends Endpoint
+  implements EndpointInterface<BingxResponse<R>>
+{
+  constructor(
+    private readonly order: QueryOrderInterface,
+    account: AccountInterface,
+  ) {
+    super(account);
+  }
+
+  readonly t!: BingxResponse<R>;
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'get';
+  }
+
+  parameters(): SignatureParametersInterface {
+    return new DefaultSignatureParameters({
+      symbol: this.order.symbol,
+      ...(this.order.orderId === undefined
+        ? {}
+        : { orderId: this.order.orderId }),
+      ...(this.order.clientOrderId === undefined
+        ? {}
+        : { clientOrderId: this.order.clientOrderId }),
+      ...(this.order.recvWindow === undefined
+        ? {}
+        : { recvWindow: this.order.recvWindow }),
+    });
+  }
+
+  path(): string {
+    return '/openApi/swap/v2/trade/order';
+  }
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -7,6 +7,7 @@ export * from './bingx-get-server-time-endpoint';
 export * from './bingx-perpetual-swap-positions-endpoint';
 export * from './bingx-request.interface';
 export * from './bingx-response.interface';
+export * from './bingx-query-order-endpoint';
 export * from './bingx-trade-order-endpoint';
 export * from './endpoint.interface';
 export * from './endpoint';

--- a/src/bingx/interfaces/query-order.interface.ts
+++ b/src/bingx/interfaces/query-order.interface.ts
@@ -1,4 +1,6 @@
 export interface QueryOrderInterface {
   symbol: string;
-  orderId: string;
+  orderId?: string;
+  clientOrderId?: string;
+  recvWindow?: string;
 }

--- a/src/bingx/interfaces/websocket-event.ts
+++ b/src/bingx/interfaces/websocket-event.ts
@@ -1,4 +1,3 @@
-import { OrderTypeEnum } from 'bingx-api/bingx/enums/order-type.enum';
 import { OrderSideEnum } from 'bingx-api/bingx/enums/order-side.enum';
 import { OrderStatusEnum } from 'bingx-api/bingx/enums/order-status.enum';
 import { OrderPositionSideEnum } from 'bingx-api/bingx/enums/order-position-side.enum';


### PR DESCRIPTION
Fixes #85

## What changed

- Added a signed `GET /openApi/swap/v2/trade/order` endpoint for querying one order.
- Exposed the endpoint through `TradeService.queryOrder`.
- Supported both `orderId` and `clientOrderId` query paths.
- Added focused tests for service dispatch, request shape, and client-order-id handling.
- Marked the README feature checkbox as supported.
- Removed one unused import so lint passes.

## Tests

- `npm test -- trade.service.spec.ts`
- `npm run lint`
- `npm run build`
