### PR TITLE
Add query leverage endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ stream.latestTradeDetail$.subscribe((v) => {})
     - [ ] Query Order
     - [ ] Query Margin Mode
     - [ ] Switch Margin Mode
-    - [ ] Query Leverage
+    - [x] Query Leverage
     - [ ] Switch Leverage
     - [ ] User's Force Orders
     - [x] User's History Orders

--- a/src/bingx-client/services/trade-query-leverage.service.spec.ts
+++ b/src/bingx-client/services/trade-query-leverage.service.spec.ts
@@ -1,0 +1,56 @@
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { BingxQueryLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-query-leverage-endpoint';
+import { TradeService } from 'bingx-api/bingx-client/services/trade.service';
+
+const account: AccountInterface = {
+  getApiKey: jest.fn().mockReturnValue('api-key'),
+  sign: jest.fn(),
+};
+
+describe('BingxQueryLeverageEndpoint', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('describes the query leverage endpoint', () => {
+    const endpoint = new BingxQueryLeverageEndpoint('BTC-USDT', account, 5000);
+
+    expect(endpoint.method()).toBe('get');
+    expect(endpoint.path()).toBe('/openApi/swap/v2/trade/leverage');
+    expect(endpoint.parameters().asRecord()).toEqual({
+      symbol: 'BTC-USDT',
+      recvWindow: '5000',
+      timestamp: '1700000000000',
+    });
+  });
+});
+
+describe('TradeService.queryLeverage', () => {
+  it('executes a query leverage endpoint', async () => {
+    const response = {
+      code: 0,
+      msg: '',
+      data: {
+        longLeverage: 20,
+        shortLeverage: 10,
+      },
+    };
+    const requestExecutor = {
+      execute: jest.fn().mockResolvedValue(response),
+    };
+    const service = new TradeService(requestExecutor);
+
+    await expect(service.queryLeverage('BTC-USDT', account)).resolves.toBe(
+      response,
+    );
+
+    expect(requestExecutor.execute).toHaveBeenCalledTimes(1);
+    expect(requestExecutor.execute).toHaveBeenCalledWith(
+      expect.any(BingxQueryLeverageEndpoint),
+    );
+  });
+});

--- a/src/bingx-client/services/trade.service.ts
+++ b/src/bingx-client/services/trade.service.ts
@@ -12,6 +12,7 @@ import { BingxSwitchLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-swi
 import { OrderPositionSideEnum } from 'bingx-api/bingx';
 import { BingxUserHistoryOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-endpoint';
 import { BingxCancelOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-cancel-order-endpoint';
+import { BingxQueryLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-query-leverage-endpoint';
 
 export class TradeService {
   constructor(private readonly requestExecutor: RequestExecutorInterface) {}
@@ -92,6 +93,16 @@ export class TradeService {
   ) {
     return this.requestExecutor.execute(
       new BingxSwitchLeverageEndpoint(symbol, leverage, side, account),
+    );
+  }
+
+  public queryLeverage(
+    symbol: string,
+    account: AccountInterface,
+    recvWindow?: string | number,
+  ) {
+    return this.requestExecutor.execute(
+      new BingxQueryLeverageEndpoint(symbol, account, recvWindow),
     );
   }
 }

--- a/src/bingx/endpoints/bingx-query-leverage-endpoint.ts
+++ b/src/bingx/endpoints/bingx-query-leverage-endpoint.ts
@@ -1,0 +1,48 @@
+import {
+  AccountInterface,
+  DefaultSignatureParameters,
+  Endpoint,
+  EndpointInterface,
+  SignatureParametersInterface,
+} from 'bingx-api/bingx';
+
+export interface QueryLeverageResponse {
+  code: number;
+  msg: string;
+  data: {
+    longLeverage: number;
+    shortLeverage: number;
+  };
+}
+
+export class BingxQueryLeverageEndpoint
+  extends Endpoint
+  implements EndpointInterface<QueryLeverageResponse>
+{
+  constructor(
+    private readonly symbol: string,
+    account: AccountInterface,
+    private readonly recvWindow?: string | number,
+  ) {
+    super(account);
+  }
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'get';
+  }
+
+  parameters(): SignatureParametersInterface {
+    return new DefaultSignatureParameters({
+      symbol: this.symbol,
+      ...(this.recvWindow === undefined
+        ? {}
+        : { recvWindow: this.recvWindow.toString() }),
+    });
+  }
+
+  path(): string {
+    return '/openApi/swap/v2/trade/leverage';
+  }
+
+  readonly t!: QueryLeverageResponse;
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -13,3 +13,4 @@ export * from './endpoint';
 export * from './bingx-user-history-orders-endpoint';
 export * from './bingx-user-history-orders-response';
 export * from './bingx-cancel-order-endpoint';
+export * from './bingx-query-leverage-endpoint';


### PR DESCRIPTION
## Summary
- add `BingxQueryLeverageEndpoint` for `GET /openApi/swap/v2/trade/leverage`
- expose it through `TradeService.queryLeverage(...)`
- export the endpoint and mark Query Leverage as implemented in the README checklist
- add focused unit coverage for endpoint parameters and service dispatch

Closes #87

/claim #87

## Validation
- `npx jest src/bingx-client/services/trade-query-leverage.service.spec.ts --runInBand`
- `npm run build`
- `npx eslint src/bingx/endpoints/bingx-query-leverage-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-query-leverage.service.spec.ts`
- `npx prettier --check src/bingx/endpoints/bingx-query-leverage-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-query-leverage.service.spec.ts`
- `git diff --check`

Implementation was prepared with AI-assisted coding and locally reviewed before submission.