### PR TITLE
Add current pending orders endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ stream.latestTradeDetail$.subscribe((v) => {})
     - [ ] Cancel an Order
     - [ ] Cancel a Batch of Orders
     - [ ] Cancel All Orders
-    - [ ] Query all current pending orders
+    - [x] Query all current pending orders
     - [ ] Query Order
     - [ ] Query Margin Mode
     - [ ] Switch Margin Mode

--- a/src/bingx-client/services/trade-current-pending-orders.service.spec.ts
+++ b/src/bingx-client/services/trade-current-pending-orders.service.spec.ts
@@ -1,0 +1,71 @@
+import { TradeService } from 'bingx-api/bingx-client/services/trade.service';
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/request-executor.interface';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+import { BingxCurrentPendingOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-current-pending-orders-endpoint';
+
+describe('trade current pending orders service', () => {
+  let account: AccountInterface;
+  let capturedEndpoints: EndpointInterface<unknown>[];
+  let requestExecutor: RequestExecutorInterface;
+  let executeSpy: jest.SpyInstance;
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    account = {
+      getApiKey: jest.fn(() => 'api-key'),
+      sign: jest.fn(() => ({
+        toString: () => 'signature',
+        secretKey: () => 'secret-key',
+      })),
+    };
+
+    capturedEndpoints = [];
+    requestExecutor = {
+      execute<T>(endpoint: EndpointInterface<T>): Promise<T> {
+        capturedEndpoints.push(endpoint as EndpointInterface<unknown>);
+        return Promise.resolve(endpoint as unknown as T);
+      },
+    };
+
+    executeSpy = jest.spyOn(requestExecutor, 'execute');
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1770000000123);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('dispatches the signed current pending orders endpoint', async () => {
+    const service = new TradeService(requestExecutor);
+
+    const endpoint = (await service.getCurrentPendingOrders(
+      {
+        symbol: 'BTC-USDT',
+        type: 'LIMIT',
+        recvWindow: 5000,
+      },
+      account,
+    )) as unknown as BingxCurrentPendingOrdersEndpoint;
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(capturedEndpoints[0]).toBe(endpoint);
+    expect(endpoint).toBeInstanceOf(BingxCurrentPendingOrdersEndpoint);
+    expect(endpoint.method()).toBe('get');
+    expect(endpoint.path()).toBe('/openApi/swap/v2/trade/openOrders');
+    expect(endpoint.parameters().asRecord()).toEqual({
+      symbol: 'BTC-USDT',
+      type: 'LIMIT',
+      recvWindow: '5000',
+      timestamp: '1770000000123',
+    });
+  });
+
+  it('omits optional filters when no pending order options are provided', () => {
+    const endpoint = new BingxCurrentPendingOrdersEndpoint({}, account);
+
+    expect(endpoint.parameters().asRecord()).toEqual({
+      timestamp: '1770000000123',
+    });
+  });
+});

--- a/src/bingx-client/services/trade.service.ts
+++ b/src/bingx-client/services/trade.service.ts
@@ -12,6 +12,10 @@ import { BingxSwitchLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-swi
 import { OrderPositionSideEnum } from 'bingx-api/bingx';
 import { BingxUserHistoryOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-endpoint';
 import { BingxCancelOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-cancel-order-endpoint';
+import {
+  BingxCurrentPendingOrdersEndpoint,
+  BingxCurrentPendingOrdersOptions,
+} from 'bingx-api/bingx/endpoints/bingx-current-pending-orders-endpoint';
 
 export class TradeService {
   constructor(private readonly requestExecutor: RequestExecutorInterface) {}
@@ -59,6 +63,15 @@ export class TradeService {
         endTime,
         account,
       ),
+    );
+  }
+
+  public async getCurrentPendingOrders(
+    options: BingxCurrentPendingOrdersOptions,
+    account: AccountInterface,
+  ) {
+    return this.requestExecutor.execute(
+      new BingxCurrentPendingOrdersEndpoint(options, account),
     );
   }
 

--- a/src/bingx/endpoints/bingx-current-pending-orders-endpoint.ts
+++ b/src/bingx/endpoints/bingx-current-pending-orders-endpoint.ts
@@ -1,0 +1,57 @@
+import {
+  AccountInterface,
+  BingxResponse,
+  DefaultSignatureParameters,
+  EndpointInterface,
+  SignatureParametersInterface,
+} from 'bingx-api/bingx';
+import { Endpoint } from 'bingx-api/bingx/endpoints/endpoint';
+import { BingxUserHistoryOrdersResponse } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-response';
+
+export interface BingxCurrentPendingOrdersOptions {
+  symbol?: string;
+  type?: string;
+  recvWindow?: string | number;
+}
+
+export class BingxCurrentPendingOrdersEndpoint<
+    R extends BingxUserHistoryOrdersResponse = BingxUserHistoryOrdersResponse,
+  >
+  extends Endpoint<BingxResponse<R>>
+  implements EndpointInterface<BingxResponse<R>>
+{
+  constructor(
+    private readonly options: BingxCurrentPendingOrdersOptions,
+    account: AccountInterface,
+  ) {
+    super(account);
+  }
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'get';
+  }
+
+  parameters(): SignatureParametersInterface {
+    const parameters: Record<string, string> = {};
+
+    if (this.options.symbol !== undefined) {
+      parameters.symbol = this.options.symbol;
+    }
+
+    if (this.options.type !== undefined) {
+      parameters.type = this.options.type;
+    }
+
+    if (this.options.recvWindow !== undefined) {
+      parameters.recvWindow = this.options.recvWindow.toString();
+    }
+
+    return new DefaultSignatureParameters(parameters);
+  }
+
+  path(): string {
+    return '/openApi/swap/v2/trade/openOrders';
+  }
+
+  readonly t!: BingxResponse<R>;
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -1,5 +1,6 @@
 export * from './bingx-cancel-all-orders-endpoint';
 export * from './bingx-close-all-positions-endpoint';
+export * from './bingx-current-pending-orders-endpoint';
 export * from './bingx-generate-listen-key-endpoint';
 export * from './bingx-generate-listen-key-response';
 export * from './bingx-get-perpetual-swap-account-asset-endpoint';


### PR DESCRIPTION
/claim #84

Closes #84

## Summary
- add the signed current pending orders endpoint for `GET /openApi/swap/v2/trade/openOrders`
- expose it through `TradeService` and the endpoint barrel export
- add focused unit coverage for service dispatch, request path/method, parameter serialization, and optional filter omission
- mark the README current pending orders feature as supported

## Validation
- `npx jest src/bingx-client/services/trade-current-pending-orders.service.spec.ts --runInBand`
- `npx eslint src/bingx/endpoints/bingx-current-pending-orders-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-current-pending-orders.service.spec.ts`
- `npx prettier --check src/bingx/endpoints/bingx-current-pending-orders-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-current-pending-orders.service.spec.ts`
- `git diff --check`
- `npm run build`

## Disclosure
Prepared with AI assistance and locally validated.