### PR TITLE
Add cancel batch orders endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ stream.latestTradeDetail$.subscribe((v) => {})
     - [ ] Bulk order
     - [x] One-Click Close All Positions
     - [ ] Cancel an Order
-    - [ ] Cancel a Batch of Orders
+    - [x] Cancel a Batch of Orders
     - [ ] Cancel All Orders
     - [ ] Query all current pending orders
     - [ ] Query Order

--- a/src/bingx-client/services/trade-cancel-batch-orders.service.spec.ts
+++ b/src/bingx-client/services/trade-cancel-batch-orders.service.spec.ts
@@ -1,0 +1,77 @@
+import { TradeService } from 'bingx-api/bingx-client/services/trade.service';
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/request-executor.interface';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+import { BingxCancelBatchOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-cancel-batch-orders-endpoint';
+
+describe('trade cancel batch orders service', () => {
+  let account: AccountInterface;
+  let capturedEndpoints: EndpointInterface<unknown>[];
+  let requestExecutor: RequestExecutorInterface;
+  let executeSpy: jest.SpyInstance;
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    account = {
+      getApiKey: jest.fn(() => 'api-key'),
+      sign: jest.fn(() => ({
+        toString: () => 'signature',
+        secretKey: () => 'secret-key',
+      })),
+    };
+
+    capturedEndpoints = [];
+    requestExecutor = {
+      execute<T>(endpoint: EndpointInterface<T>): Promise<T> {
+        capturedEndpoints.push(endpoint as EndpointInterface<unknown>);
+        return Promise.resolve(endpoint as unknown as T);
+      },
+    };
+
+    executeSpy = jest.spyOn(requestExecutor, 'execute');
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1770000000123);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('dispatches the signed cancel batch orders endpoint', async () => {
+    const service = new TradeService(requestExecutor);
+
+    const endpoint = (await service.cancelBatchOrders(
+      {
+        symbol: 'BTC-USDT',
+        orderIdList: ['1735924831603391122', '1735924833239172233'],
+        clientOrderIdList: ['abc1234567', 'abc2345678'],
+        recvWindow: 5000,
+      },
+      account,
+    )) as unknown as BingxCancelBatchOrdersEndpoint;
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(capturedEndpoints[0]).toBe(endpoint);
+    expect(endpoint).toBeInstanceOf(BingxCancelBatchOrdersEndpoint);
+    expect(endpoint.method()).toBe('delete');
+    expect(endpoint.path()).toBe('/openApi/swap/v2/trade/batchOrders');
+    expect(endpoint.parameters().asRecord()).toEqual({
+      symbol: 'BTC-USDT',
+      orderIdList: '[1735924831603391122,1735924833239172233]',
+      clientOrderIdList: '["abc1234567","abc2345678"]',
+      recvWindow: '5000',
+      timestamp: '1770000000123',
+    });
+  });
+
+  it('omits optional order lists when only the required symbol is provided', () => {
+    const endpoint = new BingxCancelBatchOrdersEndpoint(
+      { symbol: 'BTC-USDT' },
+      account,
+    );
+
+    expect(endpoint.parameters().asRecord()).toEqual({
+      symbol: 'BTC-USDT',
+      timestamp: '1770000000123',
+    });
+  });
+});

--- a/src/bingx-client/services/trade.service.ts
+++ b/src/bingx-client/services/trade.service.ts
@@ -12,6 +12,10 @@ import { BingxSwitchLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-swi
 import { OrderPositionSideEnum } from 'bingx-api/bingx';
 import { BingxUserHistoryOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-endpoint';
 import { BingxCancelOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-cancel-order-endpoint';
+import {
+  BingxCancelBatchOrdersEndpoint,
+  BingxCancelBatchOrdersOptions,
+} from 'bingx-api/bingx/endpoints/bingx-cancel-batch-orders-endpoint';
 
 export class TradeService {
   constructor(private readonly requestExecutor: RequestExecutorInterface) {}
@@ -41,6 +45,15 @@ export class TradeService {
   ) {
     return this.requestExecutor.execute(
       new BingxCancelOrderEndpoint(account, orderId, symbol),
+    );
+  }
+
+  public async cancelBatchOrders(
+    options: BingxCancelBatchOrdersOptions,
+    account: AccountInterface,
+  ) {
+    return this.requestExecutor.execute(
+      new BingxCancelBatchOrdersEndpoint(options, account),
     );
   }
 

--- a/src/bingx/endpoints/bingx-cancel-batch-orders-endpoint.ts
+++ b/src/bingx/endpoints/bingx-cancel-batch-orders-endpoint.ts
@@ -1,0 +1,76 @@
+import {
+  AccountInterface,
+  BingxResponse,
+  DefaultSignatureParameters,
+  EndpointInterface,
+  SignatureParametersInterface,
+} from 'bingx-api/bingx';
+import { Endpoint } from 'bingx-api/bingx/endpoints/endpoint';
+import { BingxUserHistoryOrdersResponse } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-response';
+
+export interface BingxCancelBatchOrdersOptions {
+  symbol: string;
+  orderIdList?: Array<string | number>;
+  clientOrderIdList?: string[];
+  recvWindow?: string | number;
+}
+
+export interface BingxCancelBatchOrdersFailedOrder {
+  orderId?: string | number;
+  clientOrderId?: string;
+  errorCode: number;
+  errorMessage: string;
+}
+
+export interface BingxCancelBatchOrdersData {
+  success: BingxUserHistoryOrdersResponse['orders'];
+  failed: BingxCancelBatchOrdersFailedOrder[] | null;
+}
+
+export class BingxCancelBatchOrdersEndpoint<R = BingxCancelBatchOrdersData>
+  extends Endpoint<BingxResponse<R>>
+  implements EndpointInterface<BingxResponse<R>>
+{
+  constructor(
+    private readonly options: BingxCancelBatchOrdersOptions,
+    account: AccountInterface,
+  ) {
+    super(account);
+  }
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'delete';
+  }
+
+  parameters(): SignatureParametersInterface {
+    const parameters: Record<string, string> = {
+      symbol: this.options.symbol,
+    };
+
+    if (this.options.orderIdList !== undefined) {
+      parameters.orderIdList = this.serializeOrderIds(this.options.orderIdList);
+    }
+
+    if (this.options.clientOrderIdList !== undefined) {
+      parameters.clientOrderIdList = JSON.stringify(
+        this.options.clientOrderIdList,
+      );
+    }
+
+    if (this.options.recvWindow !== undefined) {
+      parameters.recvWindow = this.options.recvWindow.toString();
+    }
+
+    return new DefaultSignatureParameters(parameters);
+  }
+
+  path(): string {
+    return '/openApi/swap/v2/trade/batchOrders';
+  }
+
+  private serializeOrderIds(orderIds: Array<string | number>): string {
+    return `[${orderIds.map((orderId) => orderId.toString()).join(',')}]`;
+  }
+
+  readonly t!: BingxResponse<R>;
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -1,4 +1,5 @@
 export * from './bingx-cancel-all-orders-endpoint';
+export * from './bingx-cancel-batch-orders-endpoint';
 export * from './bingx-close-all-positions-endpoint';
 export * from './bingx-generate-listen-key-endpoint';
 export * from './bingx-generate-listen-key-response';


### PR DESCRIPTION
/claim #83

Closes #83

## Summary
- add the signed cancel batch orders endpoint for `DELETE /openApi/swap/v2/trade/batchOrders`
- expose it through `TradeService` and the endpoint barrel export
- add focused unit coverage for service dispatch, request path/method, `orderIdList` and `clientOrderIdList` serialization, and optional parameter omission
- mark the README cancel batch orders feature as supported

## Validation
- `npx jest src/bingx-client/services/trade-cancel-batch-orders.service.spec.ts --runInBand`
- `npx eslint src/bingx/endpoints/bingx-cancel-batch-orders-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-cancel-batch-orders.service.spec.ts`
- `npx prettier --check src/bingx/endpoints/bingx-cancel-batch-orders-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-cancel-batch-orders.service.spec.ts`
- `git diff --check`
- `npm run build`

## Disclosure
Prepared with AI assistance and locally validated.