### PR TITLE
Add historical transaction orders endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ stream.latestTradeDetail$.subscribe((v) => {})
     - [ ] User's Force Orders
     - [x] User's History Orders
     - [ ] Adjust isolated margin
-    - [ ] Query historical transaction orders
+    - [x] Query historical transaction orders
 * Listen Key
     - [x] Generate Listen Key
     - [ ] Extend Listen Key Validity period

--- a/src/bingx-client/services/trade-historical-transaction-orders.service.spec.ts
+++ b/src/bingx-client/services/trade-historical-transaction-orders.service.spec.ts
@@ -1,0 +1,91 @@
+import { TradeService } from 'bingx-api/bingx-client/services/trade.service';
+import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
+import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/request-executor.interface';
+import { EndpointInterface } from 'bingx-api/bingx/endpoints/endpoint.interface';
+import { BingxHistoricalTransactionOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-historical-transaction-orders-endpoint';
+
+describe('trade historical transaction orders service', () => {
+  let account: AccountInterface;
+  let capturedEndpoints: EndpointInterface<unknown>[];
+  let requestExecutor: RequestExecutorInterface;
+  let executeSpy: jest.SpyInstance;
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    account = {
+      getApiKey: jest.fn(() => 'api-key'),
+      sign: jest.fn(() => ({
+        toString: () => 'signature',
+        secretKey: () => 'secret-key',
+      })),
+    };
+
+    capturedEndpoints = [];
+    requestExecutor = {
+      execute<T>(endpoint: EndpointInterface<T>): Promise<T> {
+        capturedEndpoints.push(endpoint as EndpointInterface<unknown>);
+        return Promise.resolve(endpoint as unknown as T);
+      },
+    };
+
+    executeSpy = jest.spyOn(requestExecutor, 'execute');
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1770000000123);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('dispatches the signed historical transaction orders endpoint', async () => {
+    const service = new TradeService(requestExecutor);
+    const startTs = new Date('2026-01-02T03:04:05.006Z');
+    const endTs = 1770000000000;
+
+    const endpoint = (await service.getHistoricalTransactionOrders(
+      {
+        symbol: 'WLD-USDT',
+        currency: 'USDT',
+        orderId: '1736007768311123456',
+        tradingUnit: 'COIN',
+        startTs,
+        endTs,
+        recvWindow: 5000,
+      },
+      account,
+    )) as unknown as BingxHistoricalTransactionOrdersEndpoint;
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(capturedEndpoints[0]).toBe(endpoint);
+    expect(endpoint).toBeInstanceOf(BingxHistoricalTransactionOrdersEndpoint);
+    expect(endpoint.method()).toBe('get');
+    expect(endpoint.path()).toBe('/openApi/swap/v2/trade/allFillOrders');
+    expect(endpoint.parameters().asRecord()).toEqual({
+      tradingUnit: 'COIN',
+      startTs: startTs.getTime().toString(10),
+      endTs: endTs.toString(10),
+      symbol: 'WLD-USDT',
+      currency: 'USDT',
+      orderId: '1736007768311123456',
+      recvWindow: '5000',
+      timestamp: '1770000000123',
+    });
+  });
+
+  it('omits optional filters when only required history options are provided', () => {
+    const endpoint = new BingxHistoricalTransactionOrdersEndpoint(
+      {
+        tradingUnit: 'CONT',
+        startTs: 1770000000000,
+        endTs: 1770000001000,
+      },
+      account,
+    );
+
+    expect(endpoint.parameters().asRecord()).toEqual({
+      tradingUnit: 'CONT',
+      startTs: '1770000000000',
+      endTs: '1770000001000',
+      timestamp: '1770000000123',
+    });
+  });
+});

--- a/src/bingx-client/services/trade.service.ts
+++ b/src/bingx-client/services/trade.service.ts
@@ -12,6 +12,10 @@ import { BingxSwitchLeverageEndpoint } from 'bingx-api/bingx/endpoints/bingx-swi
 import { OrderPositionSideEnum } from 'bingx-api/bingx';
 import { BingxUserHistoryOrdersEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-history-orders-endpoint';
 import { BingxCancelOrderEndpoint } from 'bingx-api/bingx/endpoints/bingx-cancel-order-endpoint';
+import {
+  BingxHistoricalTransactionOrdersEndpoint,
+  BingxHistoricalTransactionOrdersOptions,
+} from 'bingx-api/bingx/endpoints/bingx-historical-transaction-orders-endpoint';
 
 export class TradeService {
   constructor(private readonly requestExecutor: RequestExecutorInterface) {}
@@ -59,6 +63,15 @@ export class TradeService {
         endTime,
         account,
       ),
+    );
+  }
+
+  public async getHistoricalTransactionOrders(
+    options: BingxHistoricalTransactionOrdersOptions,
+    account: AccountInterface,
+  ) {
+    return this.requestExecutor.execute(
+      new BingxHistoricalTransactionOrdersEndpoint(options, account),
     );
   }
 

--- a/src/bingx/endpoints/bingx-historical-transaction-orders-endpoint.ts
+++ b/src/bingx/endpoints/bingx-historical-transaction-orders-endpoint.ts
@@ -1,0 +1,100 @@
+import {
+  AccountInterface,
+  BingxResponse,
+  DefaultSignatureParameters,
+  EndpointInterface,
+  SignatureParametersInterface,
+} from 'bingx-api/bingx';
+import { Endpoint } from 'bingx-api/bingx/endpoints/endpoint';
+
+export type TradingUnit = 'COIN' | 'CONT';
+
+export interface BingxHistoricalTransactionOrdersOptions {
+  tradingUnit: TradingUnit;
+  startTs: Date | number;
+  endTs: Date | number;
+  symbol?: string;
+  currency?: string;
+  orderId?: string | number;
+  recvWindow?: string | number;
+}
+
+export interface BingxHistoricalTransactionOrder {
+  filledTm: string;
+  symbol: string;
+  volume: string;
+  price: string;
+  amount: string;
+  commission: string;
+  currency: string;
+  orderId: string;
+  liquidatedPrice: string;
+  liquidatedMarginRatio: string;
+  filledTime: string;
+  workingType?: string;
+  side?: string;
+  type?: string;
+  positionSide?: string;
+  clientOrderID?: string;
+  onlyOnePosition?: boolean;
+}
+
+export interface BingxHistoricalTransactionOrdersData {
+  fill_orders: BingxHistoricalTransactionOrder[];
+}
+
+export class BingxHistoricalTransactionOrdersEndpoint<
+    R = BingxHistoricalTransactionOrdersData,
+  >
+  extends Endpoint<BingxResponse<R>>
+  implements EndpointInterface<BingxResponse<R>>
+{
+  constructor(
+    private readonly options: BingxHistoricalTransactionOrdersOptions,
+    account: AccountInterface,
+  ) {
+    super(account);
+  }
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'get';
+  }
+
+  parameters(): SignatureParametersInterface {
+    const parameters: Record<string, string> = {
+      tradingUnit: this.options.tradingUnit,
+      startTs: this.timestampAsString(this.options.startTs),
+      endTs: this.timestampAsString(this.options.endTs),
+    };
+
+    if (this.options.symbol !== undefined) {
+      parameters.symbol = this.options.symbol;
+    }
+
+    if (this.options.currency !== undefined) {
+      parameters.currency = this.options.currency;
+    }
+
+    if (this.options.orderId !== undefined) {
+      parameters.orderId = this.options.orderId.toString();
+    }
+
+    if (this.options.recvWindow !== undefined) {
+      parameters.recvWindow = this.options.recvWindow.toString();
+    }
+
+    return new DefaultSignatureParameters(parameters);
+  }
+
+  path(): string {
+    return '/openApi/swap/v2/trade/allFillOrders';
+  }
+
+  private timestampAsString(value: Date | number): string {
+    return value instanceof Date
+      ? value.getTime().toString(10)
+      : value.toString();
+  }
+
+  readonly t!: BingxResponse<R>;
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -4,6 +4,7 @@ export * from './bingx-generate-listen-key-endpoint';
 export * from './bingx-generate-listen-key-response';
 export * from './bingx-get-perpetual-swap-account-asset-endpoint';
 export * from './bingx-get-server-time-endpoint';
+export * from './bingx-historical-transaction-orders-endpoint';
 export * from './bingx-perpetual-swap-positions-endpoint';
 export * from './bingx-request.interface';
 export * from './bingx-response.interface';


### PR DESCRIPTION
/claim #90

Closes #90

## Summary
- add the signed historical transaction orders endpoint for `GET /openApi/swap/v2/trade/allFillOrders`
- expose it through `TradeService` and the endpoint barrel export
- add focused unit coverage for service dispatch, request path/method, required timestamp serialization, and optional filter omission
- mark the README historical transaction orders feature as supported

## Validation
- `npx jest src/bingx-client/services/trade-historical-transaction-orders.service.spec.ts --runInBand`
- `npx eslint src/bingx/endpoints/bingx-historical-transaction-orders-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-historical-transaction-orders.service.spec.ts`
- `npx prettier --check src/bingx/endpoints/bingx-historical-transaction-orders-endpoint.ts src/bingx/endpoints/index.ts src/bingx-client/services/trade.service.ts src/bingx-client/services/trade-historical-transaction-orders.service.spec.ts`
- `git diff --check`
- `npm run build`

## Disclosure
Prepared with AI assistance and locally validated.