### PR TITLE
Add account configuration update websocket event

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ stream.latestTradeDetail$.subscribe((v) => {})
         - [x] Listen Key expired push
         - [x] Account balance and position update push
         - [x] Order update push
-        - [ ] Configuration updates such as leverage and margin mode
+        - [x] Configuration updates such as leverage and margin mode

--- a/src/bingx-socket/bingx-account-socket-config-update.spec.ts
+++ b/src/bingx-socket/bingx-account-socket-config-update.spec.ts
@@ -1,0 +1,86 @@
+import { Server, WebSocket } from 'ws';
+import { getPortFree } from 'bingx-api/get-port';
+import { ApiAccount } from 'bingx-api/bingx/account/api-account';
+import { BingxAccountSocketStream } from 'bingx-api/bingx-socket/bingx-account-socket-stream';
+import * as zlib from 'zlib';
+import { AccountWebsocketEventType } from 'bingx-api/bingx-socket/events';
+
+describe('bingx account socket configuration update', () => {
+  let wss: Server;
+  let port: number;
+  let stream: BingxAccountSocketStream | undefined;
+  const sockets: WebSocket[] = [];
+
+  const sendToSocket = (socket: WebSocket, msg: string) => {
+    zlib.gzip(msg, (err, result) => {
+      socket.send(result);
+    });
+  };
+
+  beforeEach(async () => {
+    port = await getPortFree();
+    wss = new Server({ port });
+    await new Promise<void>((resolve) => {
+      wss.on('listening', resolve);
+      wss.on('connection', (ws) => {
+        sockets[0] = ws;
+        ws.on('close', () => {
+          sockets.splice(0, 1);
+        });
+      });
+    });
+  });
+
+  afterEach((done) => {
+    stream?.disconnect();
+    wss.close(() => {
+      sockets.splice(0, sockets.length);
+      done();
+    });
+  });
+
+  it('emits account configuration update events', (done) => {
+    const requestExecutorMock = {
+      execute: jest.fn().mockResolvedValueOnce({ listenKey: '123' }),
+    };
+    const account = new ApiAccount('xxx', 'xxx');
+
+    wss.once('connection', (socket) => {
+      setTimeout(() => {
+        sendToSocket(
+          socket,
+          JSON.stringify({
+            e: AccountWebsocketEventType.ACCOUNT_CONFIG_UPDATE,
+            E: 1676603102163,
+            ac: {
+              s: 'BTC-USDT',
+              l: 12,
+              S: 9,
+              mt: 'cross',
+            },
+          }),
+        );
+      }, 10);
+    });
+
+    stream = new BingxAccountSocketStream(account, {
+      requestExecutor: requestExecutorMock,
+      url: new URL('', `ws://0.0.0.0:${port}`),
+    });
+
+    stream.accountConfigurationUpdate$.subscribe((event) => {
+      expect(event).toStrictEqual({
+        e: AccountWebsocketEventType.ACCOUNT_CONFIG_UPDATE,
+        E: '1676603102163',
+        ac: {
+          s: 'BTC-USDT',
+          l: '12',
+          S: '9',
+          mt: 'cross',
+        },
+      });
+      expect(requestExecutorMock.execute).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+});

--- a/src/bingx-socket/bingx-account-socket-stream.ts
+++ b/src/bingx-socket/bingx-account-socket-stream.ts
@@ -12,6 +12,7 @@ import { BingxWebsocketSerializer } from 'bingx-api/bingx-socket/bingx-websocket
 import { HeartbeatInterface } from 'bingx-api/bingx-socket/interfaces/heartbeat.interface';
 import { filterAndEmitToSubject } from 'bingx-api/bingx-socket/operators/filter-and-emit-to-subject';
 import {
+  AccountConfigurationUpdateEvent,
   AccountBalanceAndPositionPushEvent,
   AccountOrderUpdatePushEvent,
   AccountWebSocketEvent,
@@ -36,6 +37,8 @@ export class BingxAccountSocketStream {
     new Subject<AccountBalanceAndPositionPushEvent>();
   public readonly accountOrderUpdatePushEvent$ =
     new Subject<AccountOrderUpdatePushEvent>();
+  public readonly accountConfigurationUpdate$ =
+    new Subject<AccountConfigurationUpdateEvent>();
 
   constructor(
     private readonly account: AccountInterface,
@@ -97,6 +100,11 @@ export class BingxAccountSocketStream {
           (event): event is AccountOrderUpdatePushEvent =>
             event.e === AccountWebsocketEventType.ORDER_TRADE_UPDATE,
           this.accountOrderUpdatePushEvent$,
+        ),
+        filterAndEmitToSubject(
+          (event): event is AccountConfigurationUpdateEvent =>
+            event.e === AccountWebsocketEventType.ACCOUNT_CONFIG_UPDATE,
+          this.accountConfigurationUpdate$,
         ),
       )
       .subscribe();

--- a/src/bingx-socket/events/account-websocket-events.ts
+++ b/src/bingx-socket/events/account-websocket-events.ts
@@ -60,6 +60,7 @@ export type EntryPrice = number;
 export type UnrealizedProfitAndLossPosition = number;
 export type MarginMode = string;
 export type IsolatedPositionMargin = number;
+export type AccountConfigLeverage = string | number;
 
 /**
  * Relates to order update events
@@ -139,4 +140,17 @@ export interface AccountOrderUpdatePushEvent extends AccountWebSocketEvent {
   e: AccountWebsocketEventType.ORDER_TRADE_UPDATE;
   E: EventTimeInMilliseconds;
   o: AccountWebSocketOrder;
+}
+
+export interface AccountConfiguration {
+  s: TradingPair;
+  l: AccountConfigLeverage;
+  S: AccountConfigLeverage;
+  mt: MarginMode;
+}
+
+export interface AccountConfigurationUpdateEvent extends AccountWebSocketEvent {
+  e: AccountWebsocketEventType.ACCOUNT_CONFIG_UPDATE;
+  E: EventTimeInMilliseconds;
+  ac: AccountConfiguration;
 }


### PR DESCRIPTION
/claim #93

Closes #93

## Summary
- add typed account configuration update websocket event support for `ACCOUNT_CONFIG_UPDATE`
- expose `accountConfigurationUpdate$` on `BingxAccountSocketStream`
- add focused websocket coverage for parsing leverage and margin-mode configuration updates
- mark the README account configuration update websocket feature as supported

## Validation
- `npx jest src/bingx-socket/bingx-account-socket-config-update.spec.ts --runInBand`
- `npx eslint src/bingx-socket/bingx-account-socket-stream.ts src/bingx-socket/events/account-websocket-events.ts src/bingx-socket/bingx-account-socket-config-update.spec.ts`
- `npx prettier --check src/bingx-socket/bingx-account-socket-stream.ts src/bingx-socket/events/account-websocket-events.ts src/bingx-socket/bingx-account-socket-config-update.spec.ts`
- `git diff --check`
- `npm run build`

## Disclosure
Prepared with AI assistance and locally validated.