### PR TITLE
feat(account): implement user fee rate endpoint (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ stream.latestTradeDetail$.subscribe((v) => {})
     - [x] Perpetual Swap Positions
     - [ ] Get Account Profit and Loss Fund Flow
     - [ ] Export fund flow
-    - [ ] User fee rate
+    - [x] User fee rate
 * Trade Interface
     - [ ] Trade order test
     - [x] Trade order

--- a/src/bingx-client/services/account.service.spec.ts
+++ b/src/bingx-client/services/account.service.spec.ts
@@ -1,0 +1,41 @@
+import { ApiAccount } from 'bingx-api/bingx/account/api-account';
+import { BingxUserFeeRateEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-fee-rate-endpoint';
+import { AccountService } from 'bingx-api/bingx-client/services/account.service';
+
+describe('AccountService', () => {
+  const account = new ApiAccount('api-key', 'secret-key');
+
+  it('executes user fee rate endpoint', async () => {
+    const requestExecutorMock = {
+      execute: jest.fn().mockResolvedValue({}),
+    };
+    const service = new AccountService(requestExecutorMock);
+
+    await expect(service.getUserFeeRate(account)).resolves.toEqual({});
+
+    expect(requestExecutorMock.execute).toHaveBeenCalledWith(
+      expect.any(BingxUserFeeRateEndpoint),
+    );
+
+    const endpoint = requestExecutorMock.execute.mock.calls[0][0];
+    expect(endpoint.path()).toBe('/openApi/swap/v2/user/commissionRate');
+    expect(endpoint.method()).toBe('get');
+    expect(endpoint.parameters().asRecord()).toHaveProperty('timestamp');
+  });
+
+  it('passes symbol to user fee rate endpoint parameters when provided', async () => {
+    const requestExecutorMock = {
+      execute: jest.fn().mockResolvedValue({}),
+    };
+    const service = new AccountService(requestExecutorMock);
+
+    await expect(service.getUserFeeRate(account, 'BTC-USDT')).resolves.toEqual(
+      {},
+    );
+
+    const endpoint = requestExecutorMock.execute.mock.calls[0][0];
+    expect(endpoint.parameters().asRecord()).toMatchObject({
+      symbol: 'BTC-USDT',
+    });
+  });
+});

--- a/src/bingx-client/services/account.service.ts
+++ b/src/bingx-client/services/account.service.ts
@@ -2,6 +2,7 @@ import { RequestExecutorInterface } from 'bingx-api/bingx/request-executor/reque
 import { AccountInterface } from 'bingx-api/bingx/account/account.interface';
 import { BingxGetPerpetualSwapAccountAssetEndpoint } from 'bingx-api/bingx/endpoints/bingx-get-perpetual-swap-account-asset-endpoint';
 import { BingxPerpetualSwapPositionsEndpoint } from 'bingx-api/bingx/endpoints/bingx-perpetual-swap-positions-endpoint';
+import { BingxUserFeeRateEndpoint } from 'bingx-api/bingx/endpoints/bingx-user-fee-rate-endpoint';
 
 export class AccountService {
   constructor(private readonly requestExecutor: RequestExecutorInterface) {}
@@ -15,6 +16,12 @@ export class AccountService {
   public getPerpetualSwapPositions(symbol: string, account: AccountInterface) {
     return this.requestExecutor.execute(
       new BingxPerpetualSwapPositionsEndpoint(symbol, account),
+    );
+  }
+
+  public getUserFeeRate(account: AccountInterface, symbol?: string) {
+    return this.requestExecutor.execute(
+      new BingxUserFeeRateEndpoint(account, symbol),
     );
   }
 }

--- a/src/bingx/endpoints/bingx-user-fee-rate-endpoint.ts
+++ b/src/bingx/endpoints/bingx-user-fee-rate-endpoint.ts
@@ -1,0 +1,41 @@
+import {
+  AccountInterface,
+  BingxResponse,
+  DefaultSignatureParameters,
+  EndpointInterface,
+  SignatureParametersInterface,
+} from 'bingx-api/bingx';
+import { Endpoint } from 'bingx-api/bingx/endpoints/endpoint';
+
+export interface BingxUserFeeRateData {
+  [key: string]: unknown;
+}
+
+export class BingxUserFeeRateEndpoint<R = BingxUserFeeRateData>
+  extends Endpoint
+  implements EndpointInterface<BingxResponse<R>>
+{
+  constructor(
+    account: AccountInterface,
+    private readonly symbol?: string,
+  ) {
+    super(account);
+  }
+
+  method(): 'get' | 'post' | 'put' | 'patch' | 'delete' {
+    return 'get';
+  }
+
+  parameters(): SignatureParametersInterface {
+    if (this.symbol) {
+      return new DefaultSignatureParameters({ symbol: this.symbol });
+    }
+    return new DefaultSignatureParameters();
+  }
+
+  path(): string {
+    return '/openApi/swap/v2/user/commissionRate';
+  }
+
+  readonly t!: BingxResponse<R>;
+}

--- a/src/bingx/endpoints/index.ts
+++ b/src/bingx/endpoints/index.ts
@@ -13,3 +13,4 @@ export * from './endpoint';
 export * from './bingx-user-history-orders-endpoint';
 export * from './bingx-user-history-orders-response';
 export * from './bingx-cancel-order-endpoint';
+export * from './bingx-user-fee-rate-endpoint';


### PR DESCRIPTION
Implements #80 (`Price: 10$`) by wiring the missing account feature end-to-end.

## What changed
- Added `BingxUserFeeRateEndpoint` for `GET /openApi/swap/v2/user/commissionRate`.
- Added `AccountService.getUserFeeRate(account, symbol?)` that dispatches the new endpoint.
- Exported the endpoint in `src/bingx/endpoints/index.ts`.
- Added focused unit tests in `src/bingx-client/services/account.service.spec.ts` for dispatch and optional `symbol` forwarding.
- Updated README feature status for `User fee rate` to checked.

## Validation
Validated on the current PR head (`a03308846e492e312e1d7dbcceeb19b9cdbcd9df`) in a clean checkout:
- `npm install --no-audit --no-fund` PASS
- `npx tsc --noEmit` PASS
- `npm run build --silent` PASS
- `npx jest src/bingx-client/services/account.service.spec.ts --runInBand` PASS (2 tests)